### PR TITLE
Fix Minor Grammatical Errors Update app.toml

### DIFF
--- a/testnet/app.toml
+++ b/testnet/app.toml
@@ -85,7 +85,7 @@ app-db-backend = ""
 service-name = ""
 
 # Enabled enables the application telemetry functionality. When enabled,
-# an in-memory sink is also enabled by default. Operators may also enabled
+# an in-memory sink is also enabled by default. Operators may also enable
 # other sinks such as Prometheus.
 enabled = false
 
@@ -227,7 +227,7 @@ stop-node-on-err = true
 ###############################################################################
 
 [mempool]
-# Setting max-txs to 0 will allow for a unbounded amount of transactions in the mempool.
+# Setting max-txs to 0 will allow for an unbounded amount of transactions in the mempool.
 # Setting max_txs to negative 1 (-1) will disable transactions from being inserted into the mempool (no-op mempool).
 # Setting max_txs to a positive number (> 0) will limit the number of transactions in the mempool, by the specified amount.
 #


### PR DESCRIPTION
### Description:  
This update corrects two minor grammatical errors in the configuration file comments:  

1. **[mempool]:** Corrected "a unbounded" to "an unbounded" for grammatical accuracy.  
2. **[telemetry]:** Updated "Operators may also enabled" to "Operators may also enable" to ensure proper verb usage.  

### Importance:  
While these changes are minor, accurate and professional documentation is crucial for readability and user confidence. These fixes improve the clarity of the comments and help maintain a high standard for the project’s documentation.