### PR TITLE
chore: Prometheus is enabled by default

### DIFF
--- a/testnet/config.toml
+++ b/testnet/config.toml
@@ -483,7 +483,7 @@ psql-conn = ""
 # When true, Prometheus metrics are served under /metrics on
 # PrometheusListenAddr.
 # Check out the documentation for the list of available metrics.
-prometheus = false
+prometheus = true
 
 # Address to listen for Prometheus collector(s) connections
 prometheus_listen_addr = ":26660"


### PR DESCRIPTION
Prometheus is enabled by default